### PR TITLE
Add read/write flags to create subcommand

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -21,6 +21,10 @@ pub const ISLAND_DEFAULT_CONFIG_BASE_NAME: &str = "island-default-base.toml";
 pub const ISLAND_DEFAULT_CONFIG_BASE_CONTENT: &str =
     include_str!("../assets/landlock/island-default-base.toml");
 
+pub const ISLAND_CUSTOM_CONFIG_NAME: &str = "island-custom.toml";
+pub const ISLAND_CUSTOM_CONFIG_HEADER_CONTENT: &str =
+    include_str!("../assets/landlock/island-custom-header.toml");
+
 fn check_profile_default<L>(profile_guard: &ProfileGuard<L>) -> io::Result<Option<PathBuf>>
 where
     L: ProfileLock,
@@ -478,6 +482,26 @@ impl IslandConfig {
     pub fn profile_names(&self) -> impl Iterator<Item = &String> + '_ {
         self.profiles.keys()
     }
+}
+
+pub fn generate_path_beneath_rule(allowed_access: &[String], parent: &[String]) -> String {
+    let parent_paths = parent
+        .iter()
+        .map(|path| format!("    {}", toml::Value::String(path.clone())))
+        .collect::<Vec<_>>()
+        .join(",\n")
+        + ",";
+
+    let allowed_accesses = allowed_access
+        .iter()
+        .map(|access| format!("{}", toml::Value::String(access.clone())))
+        .collect::<Vec<_>>()
+        .join(", ");
+
+    format!(
+        "[[path_beneath]]\nallowed_access = [{}]\nparent = [\n{}\n]\n",
+        allowed_accesses, parent_paths
+    )
 }
 
 #[cfg(test)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,7 +5,7 @@ use clap_complete::generate;
 use landlock::RulesetError;
 use landlockconfig::{BuildRulesetError, ParseDirectoryError, ResolveError, ResolvedConfig};
 use std::{
-    collections::BTreeMap,
+    collections::{BTreeMap, BTreeSet},
     env,
     fmt::Display,
     fs, io,
@@ -16,7 +16,10 @@ use std::{
 use thiserror::Error;
 
 mod config;
-use config::{is_profile_name_valid, ConfigError, IslandConfig, ResolvedProfile};
+use config::{
+    generate_path_beneath_rule, is_profile_name_valid, ConfigError, IslandConfig, ResolvedProfile,
+    ISLAND_CUSTOM_CONFIG_HEADER_CONTENT, ISLAND_CUSTOM_CONFIG_NAME,
+};
 
 mod context;
 
@@ -146,6 +149,26 @@ enum Commands {
                 These paths will be converted to absolute paths and stored in the profile configuration."
         )]
         when_beneath: Vec<String>,
+
+        #[arg(
+            short = 'r',
+            long,
+            help = "Allow read and execute from directory.",
+            long_help = "One or more directories the profile will be allowed to read and execute from. \
+                These paths will be converted to absolute paths and stored in the profile configuration. \
+                Equivalent to \"abi.read_execute\" in allowed_access."
+        )]
+        allow_read_execute: Vec<String>,
+
+        #[arg(
+            short = 'w',
+            long,
+            help = "Allow read and write to directory.",
+            long_help = "One or more directories the profile will be allowed to read, execute from and write to. \
+                These paths will be converted to absolute paths and stored in the profile configuration. \
+                Equivalent to \"abi.read_write\" in allowed_access."
+        )]
+        allow_read_write: Vec<String>,
     },
 
     #[command(
@@ -212,6 +235,9 @@ enum IslandError {
 
     #[error(transparent)]
     Ruleset(#[from] RulesetError),
+
+    #[error("duplicate paths between different permissions options")]
+    DuplicatedPaths(Vec<String>),
 }
 
 fn run(
@@ -386,6 +412,8 @@ fn main() -> Result<(), IslandError> {
         Commands::Create {
             name,
             when_beneath: paths,
+            allow_read_write,
+            allow_read_execute,
         } => {
             if !is_profile_name_valid(&name) {
                 return Err(IslandError::Io(io::Error::new(
@@ -425,6 +453,50 @@ fn main() -> Result<(), IslandError> {
                 landlock_dir.join("island-default-base.toml"),
                 config::ISLAND_DEFAULT_CONFIG_BASE_CONTENT,
             )?;
+
+            let allow_read_write = allow_read_write
+                .iter()
+                .map(|path| Ok(try_canonicalize(path)?.to_string_lossy().into()))
+                .collect::<Result<Vec<String>, io::Error>>()?;
+
+            let allow_read_execute = allow_read_execute
+                .iter()
+                .map(|path| Ok(try_canonicalize(path)?.to_string_lossy().into()))
+                .collect::<Result<Vec<String>, io::Error>>()?;
+
+            let allow_read_write: BTreeSet<String> = allow_read_write.iter().cloned().collect();
+            let allow_read_execute: BTreeSet<String> = allow_read_execute.iter().cloned().collect();
+
+            let rw_and_rx = allow_read_write.intersection(&allow_read_execute);
+            let rw_and_rx: Vec<String> = rw_and_rx.cloned().collect();
+            if !rw_and_rx.is_empty() {
+                Err(IslandError::DuplicatedPaths(rw_and_rx))?
+            }
+
+            let allow_read_write: Vec<String> = allow_read_write.iter().cloned().collect();
+            let allow_read_execute: Vec<String> = allow_read_execute.iter().cloned().collect();
+
+            let read_write_config =
+                generate_path_beneath_rule(&["abi.read_write".into()], &allow_read_write);
+
+            let read_execute_config =
+                generate_path_beneath_rule(&["abi.read_execute".into()], &allow_read_execute);
+
+            let mut custom_config = String::from(ISLAND_CUSTOM_CONFIG_HEADER_CONTENT);
+
+            if !allow_read_execute.is_empty() {
+                custom_config += "\n";
+                custom_config += &read_execute_config;
+            }
+
+            if !allow_read_write.is_empty() {
+                custom_config += "\n";
+                custom_config += &read_write_config;
+            }
+
+            if !allow_read_write.is_empty() || !allow_read_execute.is_empty() {
+                std::fs::write(landlock_dir.join(ISLAND_CUSTOM_CONFIG_NAME), custom_config)?;
+            }
 
             println!("Created profile \"{}\" in {}", name, profile_dir.display());
             println!("It applies to:");


### PR DESCRIPTION
Flags allow user to specify what directories the profile will have access to. -r adds read and execute permissions (abi.read_execute), -w adds read, write and execute permissions (abi.read_write).

What's obviously missing from this patch is tests and perhaps some documentation, so it's not ready to be merged as-is. I wanted to first make sure that the idea is ok and compatible with design goals of island, that a patch the core cli interface would be welcome etc. etc.

PS. I wanted to make a tool like island for some time already, but I couldn't come up with a design I would be satisfied with. I think a convenient sandbox is a big missing piece of Linux CLI environment, so I'm very happy to see that it's an official project under the Landlock umbrella. :)