### PR TITLE
Add fish shell hooks

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,13 @@ $ ls
 bin  boot  dev	etc  home  [...]
 ```
 
+Fish shell users can use the following instead:
+
+```fish
+$ source (island completion fish | psub)
+$ source (island hook fish | psub)
+```
+
 ## How it works
 
 Profiles are stored in `~/.config/island/profiles/<name>/` and contain:

--- a/assets/shell/hook.fish
+++ b/assets/shell/hook.fish
@@ -1,0 +1,455 @@
+#!/usr/bin/env fish
+# SPDX-License-Identifier: Apache-2.0 OR MIT
+#
+# Island shell integration for Fish: https://github.com/landlock-lsm/island
+#
+# # Usage
+#
+# Add this to your ~/.config/fish/config.fish:
+#
+#   source (island hook fish | psub)
+#
+# You can use the $_ISLAND_PROFILES array in your prompt to display the
+# active Island profiles, or just to display if the current working directory is
+# handled. For example:
+#
+# functions --copy fish_prompt _orig_fish_prompt
+# function fish_prompt
+#     if test -n "$_ISLAND_PROFILES"
+#         echo -sn (set_color blue) "island: " "$_ISLAND_PROFILES" " "
+#     end
+#     _orig_fish_prompt
+# end
+#
+# # Goal
+#
+# Transparently sandbox commands (e.g., `ls`, `make`) when running in an
+# Island-managed directory, without changing the user experience.
+#
+# # Features
+# - Pipeline support (sandboxes `date` and `head` in `date | head`).
+# - Command chaining support (sandboxes `ls` and `echo` in `ls && echo
+#   done` and its variants).
+# - Idempotency: This script is safe to source multiple times.
+#
+# # Limitations
+#
+# - No handling of command substitutions.
+#
+# - Since aliases are defined as functions in fish, they are not easy to
+#   resolve automatically.  For alias-like behavior, use `abbr` instead,
+#   which will automatically expand before execution.
+#
+# - No support for functions.  This includes things like the built-in `ls`
+#   and `ll`, `man`, etc.  (They will still work, but won't be sandboxed.)
+#
+# # Note
+# - Fish has no ${(z)BUFFER} equivalent (`commandline --tokens-expanded` /
+#   `commandline -o` drops operators), and so this file implements a
+#   best-effort parser to handle quoted strings, operators, etc.
+
+# Ensure clean state if re-sourced.
+if functions -q _island_unhook
+    _island_unhook
+end
+
+function _island_chpwd --on-variable PWD
+    set -l profiles (command island status 2>/dev/null)
+    if test $status -eq 0
+        set -g _ISLAND_PROFILES $profiles
+    else
+        set -e _ISLAND_PROFILES
+    end
+end
+
+function nosandbox
+    if test (count $argv) -eq 0
+        return 0
+    end
+    command $argv
+end
+complete -c nosandbox -w command
+
+function _island_wrap_cmd --argument-names cmd
+    if test -z "$cmd"
+        return
+    end
+    if test "$cmd" = "island"
+        return
+    end
+
+    set -l cmd_type (type -t -- $cmd 2>/dev/null)
+    if test "$cmd_type" = "function" -o "$cmd_type" = "builtin"
+        return
+    end
+    if test "$cmd_type" = ""
+        return
+    end
+
+    if set -q _ISLAND_WRAPPED_CMDS[1]
+        if contains -- $cmd $_ISLAND_WRAPPED_CMDS
+            return
+        end
+    end
+
+    set escaped (string escape -- $cmd)
+
+    eval "
+    function $escaped --wraps $escaped
+        command island run -- $escaped \$argv
+    end
+    "
+    if test $status -ne 0
+        return 1
+    end
+
+    set -g _ISLAND_WRAPPED_CMDS $cmd $_ISLAND_WRAPPED_CMDS
+end
+
+function _island_accept_line
+    commandline --is-valid
+    set -l cl_status $status
+    if test $cl_status -ne 0
+        return
+    end
+
+    if not set -q _ISLAND_PROFILES[1]
+        return
+    end
+
+    if set -q _ISLAND_WRAPPED_CMDS[1]
+        for cmd in $_ISLAND_WRAPPED_CMDS
+            functions -e -- $cmd
+        end
+    end
+    set -g _ISLAND_WRAPPED_CMDS
+
+    set -l input_lines (commandline --current-buffer)
+
+    # If the user has typed an abbr, it might not have expanded yet.  This
+    # will result in us not "catching" the expanded command, which is
+    # unsafe.  Therefore we bail out and force the abbr expansion to
+    # happen first.  Due to the async nature of `commandline -f`, we will
+    # have to force the user to press enter again.  (We could technically
+    # parse the abbr --show output and do the expansion ourselves, but for
+    # now this is fine)
+
+    for line in $input_lines
+        if abbr --query "$line" >/dev/null 2>&1
+            commandline --function expand-abbr repaint
+            return 1
+        end
+    end
+
+    # If the completion pager is active, let the default behavior handle
+    # it (since if we modify the commandline, the pager will disappear,
+    # causing the command to execute when the user only intends to select
+    # a completion).
+    if commandline --paging-mode
+        return
+    end
+
+
+    set -l output_lines
+    set -l curr_line_out ""
+    set -l curr_token ""
+    set -l expecting_cmd 1
+    set -l in_squote 0
+    set -l in_dquote 0
+    set -l escaped 0
+    set -l modified 0
+    set -l curr_cmd_nosandbox 0
+
+    function _island_append_token_to_out --no-scope-shadowing
+        set curr_line_out "$curr_line_out$curr_token"
+        set curr_token ""
+    end
+
+    function _island_process_curr_token --no-scope-shadowing
+        if test -z "$curr_token"
+            return
+        end
+
+        set -l unescaped (string unescape -- "$curr_token")
+
+        if test $expecting_cmd -eq 1
+            # This is the first token of a command.
+
+            # First looks for "special" cases - in these cases, keep
+            # expecting_cmd as 1 and return as the next token is still
+            # going to be the command.
+
+            if test "$unescaped" = "nosandbox"
+                set curr_cmd_nosandbox 1
+                # Preserve "nosandbox" in history.
+                _island_append_token_to_out
+                return
+            end
+
+            # env assignment cannot be in a quoted string, so test $curr_token
+            if string match -qr '^[A-Za-z_][A-Za-z0-9_]*[+]?=.*' -- $curr_token
+                _island_append_token_to_out
+                return
+            end
+
+            if test "$unescaped" = "and" -o "$unescaped" = "or"
+                _island_append_token_to_out
+                return
+            end
+
+            # We have a normal command name now.
+            set expecting_cmd 0
+
+            if test $curr_cmd_nosandbox -eq 1
+                _island_append_token_to_out
+                set curr_cmd_nosandbox 0
+                return
+            end
+
+            if string match -qr '/' -- "$unescaped"
+                set curr_line_out "$curr_line_out""island run -- $curr_token"
+                set curr_token ""
+                set modified 1
+                return
+            end
+
+            _island_wrap_cmd "$unescaped"
+            if test $status -ne 0
+                # failed to define wrapper, use `island run --` insertion instead.
+                set curr_line_out "$curr_line_out""island run -- $curr_token"
+                set curr_token ""
+                set modified 1
+                return
+            end
+
+            _island_append_token_to_out
+        else
+            _island_append_token_to_out
+        end
+    end
+
+    for line in $input_lines
+        # string sub starts at 1
+        set -l i 1
+        set -l len (string length -- $line)
+        while test $i -le $len
+            set -l ch (string sub -s $i -l 1 -- $line)
+
+            if test $escaped -eq 1
+                # we already added `\` to curr_token
+                set curr_token "$curr_token$ch"
+                set escaped 0
+                set i (math $i + 1)
+                continue
+            end
+
+            # In fish, escaping works in single and double quoted strings
+            if test "$ch" = "\\"
+                set escaped 1
+                set curr_token "$curr_token$ch"
+                set i (math $i + 1)
+                continue
+            end
+
+            if test $in_squote -eq 1
+                if test "$ch" = "'"
+                    set in_squote 0
+                end
+                set curr_token "$curr_token$ch"
+                set i (math $i + 1)
+                continue
+            end
+
+            if test $in_dquote -eq 1
+                if test "$ch" = '"'
+                    set in_dquote 0
+                end
+                set curr_token "$curr_token$ch"
+                set i (math $i + 1)
+                continue
+            end
+
+            if test "$ch" = "'"
+                set in_squote 1
+                set i (math $i + 1)
+                set curr_token "$curr_token$ch"
+                continue
+            end
+
+            if test "$ch" = '"'
+                set in_dquote 1
+                set i (math $i + 1)
+                set curr_token "$curr_token$ch"
+                continue
+            end
+
+            if test "$ch" = "#"
+                _island_process_curr_token
+                set remaining (string sub -s $i -- $line)
+                set curr_line_out "$curr_line_out$remaining"
+                # skip rest of the line
+                set i (math $len + 1)
+                break
+            end
+
+            set -l remaining (string sub -s $i -- $line)
+            set -l sep_len 0
+            set -l sep_value ""
+            set -l separator_specs \
+                "^\n" \
+                "^;" \
+                "^&" \
+                "^&&" \
+                "^\\|\\|" \
+                "^\\|" \
+                "^&\\|" \
+                "^\\d+>\\|"
+
+            for spec in $separator_specs
+                set -l m (string match -r -- $spec $remaining)
+                if test (count $m) -gt 0
+                    set sep_value $m[1]
+                    set sep_len (string length -- $sep_value)
+                    break
+                end
+            end
+
+            if test $sep_len -gt 0
+                _island_process_curr_token
+                set expecting_cmd 1
+                set curr_line_out "$curr_line_out$sep_value"
+                set i (math $i + $sep_len)
+                continue
+            end
+
+            # We don't need to handle things like 2>/dev/null since these
+            # necessarily has to follow a space, and thus we would already
+            # have separated the previous token.
+            set -l redir (string match -r -- "^(>>|<<|>|<)" $remaining)
+            if test (count $redir) -gt 0
+                _island_process_curr_token
+                set curr_line_out "$curr_line_out$redir[1]"
+                set i (math $i + (string length -- $redir[1]))
+                continue
+            end
+
+            if string match -qr '^[ \t]$' -- $ch
+                _island_process_curr_token
+                set curr_line_out "$curr_line_out$ch"
+                set i (math $i + 1)
+                continue
+            end
+
+            set i (math $i + 1)
+            set curr_token "$curr_token$ch"
+        end
+
+        _island_process_curr_token
+        set output_lines $output_lines $curr_line_out
+        set curr_line_out ""
+        set expecting_cmd 1
+    end
+
+    if test $modified -eq 1
+        commandline --replace -- $output_lines
+    end
+
+    return 0
+end
+
+function _island_accept_line_normal
+    _island_accept_line
+    if test $status -ne 0
+        return
+    end
+
+    if set -q _island_orig_accept_line_normal
+        eval "$_island_orig_accept_line_normal"
+    else
+        commandline --function execute
+    end
+end
+
+function _island_accept_line_vi
+    _island_accept_line
+    if test $status -ne 0
+        return
+    end
+
+    if set -q _island_orig_accept_line_vi
+        eval "$_island_orig_accept_line_vi"
+    else
+        commandline --function execute
+    end
+end
+
+function _island_precmd --on-event fish_prompt
+    if not set -q _ISLAND_WRAPPED_CMDS[1]
+        return 0
+    end
+    for cmd in $_ISLAND_WRAPPED_CMDS
+        functions -e -- $cmd
+    end
+    set -e _ISLAND_WRAPPED_CMDS
+end
+
+function island
+    command island $argv
+    set -l ret $status
+    _island_chpwd
+    return $ret
+end
+
+function _island_unhook
+    bind --erase \r
+    bind -M insert --erase \r
+    if set -q _island_orig_accept_line_normal
+        bind \r $_island_orig_accept_line_normal
+        set -e _island_orig_accept_line_normal
+    end
+    if set -q _island_orig_accept_line_vi
+        bind -M insert \r $_island_orig_accept_line_vi
+        set -e _island_orig_accept_line_vi
+    end
+
+    if functions -q _island_precmd
+        _island_precmd
+    end
+
+    functions -e _island_accept_line
+    functions -e _island_chpwd
+    functions -e _island_precmd
+    functions -e _island_unhook
+    functions -e _island_wrap_cmd
+    functions -e nosandbox
+    functions -e island
+
+    set -e _ISLAND_PROFILES
+    set -e _ISLAND_WRAPPED_CMDS
+    complete -c nosandbox --erase
+end
+
+if status is-interactive
+    set -l old_bind (bind --user \r 2>/dev/null)
+    set -l match (string match -r '^bind enter ([a-zA-Z0-9_-]+)$' -- $old_bind)
+
+    if test (count $match) -eq 2
+        set -g _island_orig_accept_line_normal $match[2]
+    else
+        set -e _island_orig_accept_line_normal
+    end
+
+    set -l old_bind (bind --user -M insert \r 2>/dev/null)
+    set -l match (string match -r '^bind -M insert enter ([a-zA-Z0-9_-]+)$' -- $old_bind)
+    if test (count $match) -eq 2
+        set -g _island_orig_accept_line_vi $match[2]
+    else
+        set -e _island_orig_accept_line_vi
+    end
+
+    bind \r _island_accept_line_normal
+    # Make it work under fish_vi_key_bindings
+    bind -M insert \r _island_accept_line_vi
+end
+
+_island_chpwd

--- a/assets/shell/hook.fish
+++ b/assets/shell/hook.fish
@@ -113,7 +113,7 @@ function _island_wrap_cmd --argument-names cmd
         end
     end
 
-    set escaped (string escape -- $cmd)
+    set -l escaped (string escape -- $cmd)
 
     eval "
     function $escaped --wraps $escaped
@@ -169,7 +169,6 @@ function _island_accept_line
     if commandline --paging-mode
         return
     end
-
 
     set -l output_lines
     set -l curr_line_out ""
@@ -316,14 +315,16 @@ function _island_accept_line
             set -l remaining (string sub -s $i -- $line)
             set -l sep_len 0
             set -l sep_value ""
+
+            # Order matters here - when two operators share a prefix,
+            # match the longer one first.
             set -l separator_specs \
-                "^\n" \
                 "^;" \
-                "^&" \
                 "^&&" \
+                "^&\\|" \
+                "^&" \
                 "^\\|\\|" \
                 "^\\|" \
-                "^&\\|" \
                 "^\\d+>\\|"
 
             for spec in $separator_specs
@@ -338,6 +339,7 @@ function _island_accept_line
             if test $sep_len -gt 0
                 _island_process_curr_token
                 set expecting_cmd 1
+                set curr_cmd_nosandbox 0
                 set curr_line_out "$curr_line_out$sep_value"
                 set i (math $i + $sep_len)
                 continue
@@ -369,6 +371,7 @@ function _island_accept_line
         set output_lines $output_lines $curr_line_out
         set curr_line_out ""
         set expecting_cmd 1
+        set curr_cmd_nosandbox 0
     end
 
     if test $modified -eq 1
@@ -438,6 +441,8 @@ function _island_unhook
     end
 
     functions -e _island_accept_line
+    functions -e _island_accept_line_normal
+    functions -e _island_accept_line_vi
     functions -e _island_chpwd
     functions -e _island_precmd
     functions -e _island_unhook

--- a/assets/shell/hook.fish
+++ b/assets/shell/hook.fish
@@ -43,6 +43,27 @@
 # - No support for functions.  This includes things like the built-in `ls`
 #   and `ll`, `man`, etc.  (They will still work, but won't be sandboxed.)
 #
+# - fish functions does not support streaming output when inside a
+#   pipeline (all outputs are buffered and printed at once at exit) [1][2].
+#   This means that with this hook, a command like
+#
+#     base64 /dev/urandom | head
+#
+#   will show nothing and eventually run out of memory, since `base64`
+#   (and `head`) is redefined to be a function.  `nosandbox` does not help
+#   here, to work around this, you need to use `command` on either side:
+#
+#     command base64 /dev/urandom | head
+#     base64 /dev/urandom | command head
+#
+#   alternatively, to still sandbox both end of the pipe, you can manually
+#   start a one-off shell:
+#
+#     fish -c 'base64 /dev/urandom | head'
+#
+#  [1]: https://github.com/fish-shell/fish-shell/issues/1396
+#  [2]: https://github.com/fish-shell/fish-shell/issues/5635
+#
 # # Note
 # - Fish has no ${(z)BUFFER} equivalent (`commandline --tokens-expanded` /
 #   `commandline -o` drops operators), and so this file implements a

--- a/src/main.rs
+++ b/src/main.rs
@@ -43,6 +43,7 @@ impl Verbose {
 #[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, ValueEnum)]
 enum HookShell {
     Zsh,
+    Fish,
 }
 
 // Only list shells running on Linux.
@@ -113,10 +114,10 @@ enum Commands {
     #[command(
         about = "Print shell integration script",
         long_about = "Output a shell script that can be sourced to integrate island with your shell. \
-            Currently supports Zsh."
+            Supports Zsh and Fish."
     )]
     Hook {
-        #[arg(help = "Shell to generate integration for (currently only Zsh is supported)")]
+        #[arg(help = "Shell to generate integration for (zsh or fish)")]
         shell: HookShell,
 
         #[arg(long, help = "Output the script to remove the shell integration")]
@@ -378,6 +379,13 @@ fn main() -> Result<(), IslandError> {
                         println!("_island_unhook 2>/dev/null || :");
                     } else {
                         println!("{}", include_str!("../assets/shell/hook.zsh"));
+                    }
+                }
+                HookShell::Fish => {
+                    if undo {
+                        println!("_island_unhook 2>/dev/null; or true");
+                    } else {
+                        println!("{}", include_str!("../assets/shell/hook.fish"));
                     }
                 }
             }

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -95,6 +95,28 @@ mod shell_hook {
     }
 }
 
+mod shell_hook_fish {
+    run_tests! {
+        "tests/shell/test_hook.fish",
+        {
+            test_profiles_tracking,
+            test_path_rewrite,
+            test_path_rewrite_quoted,
+            test_path_rewrite_escaped,
+            test_path_rewrite_space,
+            test_quoted_command_wrapping,
+            test_nosandbox,
+            test_and_variants,
+            test_pipe_wrapping,
+            test_redirections,
+            test_invalid_commandline,
+            test_cleanup_event,
+            test_island_refreshes_profiles,
+            test_paging_mode_skip,
+        }
+    }
+}
+
 mod create {
     run_tests! {
         "tests/commands/test_create.sh",

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -106,6 +106,7 @@ mod shell_hook_fish {
             test_path_rewrite_space,
             test_quoted_command_wrapping,
             test_nosandbox,
+            test_operators,
             test_and_variants,
             test_pipe_wrapping,
             test_redirections,

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -106,6 +106,7 @@ mod shell_hook_fish {
             test_path_rewrite_space,
             test_quoted_command_wrapping,
             test_nosandbox,
+            test_nosandbox_with_separator,
             test_operators,
             test_and_variants,
             test_pipe_wrapping,

--- a/tests/shell/test_hook.fish
+++ b/tests/shell/test_hook.fish
@@ -161,6 +161,34 @@ function test_nosandbox
     tap_pass
 end
 
+function test_nosandbox_with_separator
+    tap_start "nosandbox flag doesn't persist after separator"
+    setup
+    set -g _ISLAND_PROFILES profile1
+
+    set -g __island_cmdline_buffer "nosandbox head; tail"
+    _island_accept_line
+    assert_not_contains head "command with nosandbox should not be wrapped" $_ISLAND_WRAPPED_CMDS
+    assert_contains tail "command after separator should be wrapped" $_ISLAND_WRAPPED_CMDS
+
+    set -g __island_cmdline_buffer "nosandbox /bin/echo hi; /bin/cat file"
+    _island_accept_line
+    assert_eq "$__island_cmdline_buffer" "nosandbox /bin/echo hi; island run -- /bin/cat file" "Second command after separator should be wrapped"
+    assert_not_contains /bin/echo "first command with nosandbox should not be wrapped" $_ISLAND_WRAPPED_CMDS
+
+    set -g __island_cmdline_buffer "nosandbox head" "tail"
+    _island_accept_line
+    assert_not_contains head "command with nosandbox should not be wrapped" $_ISLAND_WRAPPED_CMDS
+    assert_contains tail "command after newline should be wrapped" $_ISLAND_WRAPPED_CMDS
+
+    set -g __island_cmdline_buffer "nosandbox /bin/head" "/bin/tail"
+    _island_accept_line
+    # Test harness joins multiline output
+    assert_eq "$__island_cmdline_buffer" "nosandbox /bin/head island run -- /bin/tail" "Second command after newline should be wrapped"
+
+    tap_pass
+end
+
 function test_operators
     tap_start "Shell operators && and ||"
     setup
@@ -339,6 +367,7 @@ set TESTS \
     test_path_rewrite_space \
     test_quoted_command_wrapping \
     test_nosandbox \
+    test_nosandbox_with_separator \
     test_operators \
     test_and_variants \
     test_pipe_wrapping \

--- a/tests/shell/test_hook.fish
+++ b/tests/shell/test_hook.fish
@@ -1,0 +1,343 @@
+#!/usr/bin/env fish
+# SPDX-License-Identifier: Apache-2.0 OR MIT
+
+set -g TEST_NUM 0
+set -g CURRENT_TEST_DESC ""
+
+function tap_start --argument-names desc
+    set -g TEST_NUM (math $TEST_NUM + 1)
+    set -g CURRENT_TEST_DESC $desc
+end
+
+function tap_debug --argument-names msg
+    echo "# DEBUG: $msg" >&2
+end
+
+function tap_fail --argument-names msg
+    echo "not ok $TEST_NUM - $CURRENT_TEST_DESC: $msg"
+    exit 1
+end
+
+function tap_pass
+    echo "ok $TEST_NUM - $CURRENT_TEST_DESC"
+end
+
+function tap_plan --argument-names count
+    echo "1..$count"
+end
+
+set -gx HOME (mktemp -d)
+set -l SCRIPT_DIR (dirname (status filename))
+set -l HOOK_SCRIPT "$SCRIPT_DIR/../../assets/shell/hook.fish"
+
+set -x PATH "$SCRIPT_DIR/test_stub:$PATH"
+
+set -g __island_cmdline_buffer ""
+set -g __island_cmdline_valid_status 0
+set -g __island_cmdline_paging_mode 0
+
+function commandline
+    set -l cmd $argv[1]
+    switch $cmd
+        case "--is-valid"
+            return $__island_cmdline_valid_status
+        case "--paging-mode"
+            if test "$__island_cmdline_paging_mode" -eq 1
+                return 0
+            else
+                return 1
+            end
+        case "--current-buffer"
+            printf "%s" "$__island_cmdline_buffer"
+            return 0
+        case "--replace"
+            set -l idx 2
+            if test (count $argv) -ge 2 -a "$argv[2]" = "--"
+                set idx 3
+            end
+            if test (count $argv) -ge $idx
+                set -l rest $argv[$idx..-1]
+                set -g __island_cmdline_buffer "$rest"
+            else
+                set -g __island_cmdline_buffer ""
+            end
+            return 0
+    end
+    return 0
+end
+
+function bind
+    :
+end
+
+source "$HOOK_SCRIPT"
+
+function setup
+    # Reset state between tests
+    set -g __island_cmdline_buffer ""
+    set -g __island_cmdline_valid_status 0
+    set -g __island_cmdline_paging_mode 0
+    set -gx ISLAND_STATUS_OUTPUT ""
+    set -gx ISLAND_STATUS_EXIT 0
+    set -gx ISLAND_RUN_LOG (mktemp)
+    set -e _ISLAND_PROFILES
+    set -e _ISLAND_WRAPPED_CMDS
+end
+
+function assert_eq --argument-names actual expected msg
+    if test "$actual" != "$expected"
+        tap_fail "$msg (expected '$expected', got '$actual')"
+    end
+end
+
+function assert_contains --argument-names needle msg
+    set -l list $argv[3..-1]
+    if not contains -- $needle $list
+        tap_fail "$msg"
+    end
+end
+
+function assert_not_contains --argument-names needle msg
+    set -l list $argv[3..-1]
+    if contains -- $needle $list
+        tap_fail "$msg"
+    end
+end
+
+function test_profiles_tracking
+    tap_start "Profiles tracking via _island_chpwd"
+    setup
+    set -gx ISLAND_STATUS_OUTPUT a b
+    _island_chpwd
+    assert_eq "$_ISLAND_PROFILES" "a b" "_ISLAND_PROFILES not set"
+
+    set -gx ISLAND_STATUS_EXIT 1
+    _island_chpwd
+    if set -q _ISLAND_PROFILES[1]
+        tap_fail "_ISLAND_PROFILES not cleared on failure"
+    end
+    tap_pass
+end
+
+function test_path_rewrite
+    tap_start "Path command rewrites buffer"
+    setup
+    set -g _ISLAND_PROFILES alpha
+    set -g __island_cmdline_buffer "/bin/echo hi"
+    _island_accept_line
+    assert_eq "$__island_cmdline_buffer" "island run -- /bin/echo hi" "Buffer not rewritten"
+    tap_pass
+end
+
+function test_path_rewrite_quoted
+    tap_start "Path rewrite preserves quoting"
+    setup
+    set -g _ISLAND_PROFILES alpha
+    set -g __island_cmdline_buffer "./'my binary' arg"
+    _island_accept_line
+    assert_eq "$__island_cmdline_buffer" "island run -- ./'my binary' arg" "Quoted path not rewritten"
+    tap_pass
+end
+
+function test_path_rewrite_escaped
+    tap_start "Path rewrite handles escaped spaces"
+    setup
+    set -g _ISLAND_PROFILES alpha
+    set -g __island_cmdline_buffer "./my\\ binary"
+    _island_accept_line
+    assert_eq "$__island_cmdline_buffer" "island run -- ./my\\ binary" "Escaped path not rewritten"
+    tap_pass
+end
+
+function test_path_rewrite_space
+    tap_start "Path rewrite handles space-quoted path"
+    setup
+    set -g _ISLAND_PROFILES alpha
+    set -g __island_cmdline_buffer "./my binary"
+    _island_accept_line
+    assert_eq "$__island_cmdline_buffer" "island run -- ./my binary" "Space path not rewritten"
+    tap_pass
+end
+
+function test_quoted_command_wrapping
+    tap_start "Quoted args keep command wrapping"
+    setup
+    set -g _ISLAND_PROFILES alpha
+    functions -e ls 2>/dev/null
+    set -g __island_cmdline_buffer "ls \"file with >> weird name\""
+    _island_accept_line
+    assert_contains ls "ls not wrapped" $_ISLAND_WRAPPED_CMDS
+    assert_eq "$__island_cmdline_buffer" "ls \"file with >> weird name\"" "Buffer modified unexpectedly"
+    tap_pass
+end
+
+function test_nosandbox
+    tap_start "nosandbox bypasses wrapping"
+    setup
+    set -g _ISLAND_PROFILES alpha
+    set -g __island_cmdline_buffer "nosandbox /bin/echo hi"
+    _island_accept_line
+    assert_eq "$__island_cmdline_buffer" "nosandbox /bin/echo hi" "Buffer should remain unchanged"
+    assert_not_contains /bin/echo "nosandbox should skip wrapping" $_ISLAND_WRAPPED_CMDS
+    tap_pass
+end
+
+function test_and_variants
+    tap_start "Logical and separators"
+    setup
+    set -g _ISLAND_PROFILES alpha
+
+    set -g __island_cmdline_buffer "head a; and tail b"
+    _island_accept_line
+    assert_contains head "first command not wrapped" $_ISLAND_WRAPPED_CMDS
+    assert_contains tail "command not wrapped after \`; and\`" $_ISLAND_WRAPPED_CMDS
+
+    set -g __island_cmdline_buffer "head a and tail b"
+    _island_accept_line
+    assert_contains head "first command not wrapped" $_ISLAND_WRAPPED_CMDS
+    if contains -- tail $_ISLAND_WRAPPED_CMDS
+        tap_fail "'and' without leading separator should not wrap second command"
+    end
+    tap_pass
+end
+
+function test_pipe_wrapping
+    tap_start "Wrapping with pipe variants"
+    setup
+    set -g _ISLAND_PROFILES alpha
+    set -g __island_cmdline_buffer "echo hi &| cat 2>| head"
+    _island_accept_line
+    tap_debug "Wrapped: $_ISLAND_WRAPPED_CMDS"
+    assert_contains cat "cat not wrapped" $_ISLAND_WRAPPED_CMDS
+    assert_contains head "head not wrapped" $_ISLAND_WRAPPED_CMDS
+    tap_pass
+end
+
+function test_redirections
+    tap_start "Redirections split tokens without new command"
+    setup
+    set -g _ISLAND_PROFILES alpha
+    functions -e ls 2>/dev/null
+
+    set -g __island_cmdline_buffer "ls>a"
+    _island_accept_line
+    assert_contains ls "ls not wrapped for >" $_ISLAND_WRAPPED_CMDS
+    assert_eq "$__island_cmdline_buffer" "ls>a" "Buffer changed with >"
+
+    set -g __island_cmdline_buffer "ls>>a"
+    _island_accept_line
+    assert_contains ls "ls not wrapped for >>" $_ISLAND_WRAPPED_CMDS
+    assert_eq "$__island_cmdline_buffer" "ls>>a" "Buffer changed with >>"
+
+    set -g __island_cmdline_buffer "ls<a"
+    _island_accept_line
+    assert_contains ls "ls not wrapped for <" $_ISLAND_WRAPPED_CMDS
+    assert_eq "$__island_cmdline_buffer" "ls<a" "Buffer changed with <"
+
+    set -g __island_cmdline_buffer "ls<<a"
+    _island_accept_line
+    assert_contains ls "ls not wrapped for <<" $_ISLAND_WRAPPED_CMDS
+    assert_eq "$__island_cmdline_buffer" "ls<<a" "Buffer changed with <<"
+
+    tap_pass
+end
+
+function test_invalid_commandline
+    tap_start "Invalid commandline skips wrapping"
+    setup
+    set -g _ISLAND_PROFILES alpha
+    set -g __island_cmdline_buffer "echo 'unterminated"
+    set -g __island_cmdline_valid_status 2
+    _island_accept_line
+    assert_eq "$__island_cmdline_buffer" "echo 'unterminated" "Buffer modified unexpectedly"
+    if set -q _ISLAND_WRAPPED_CMDS[1]
+        tap_fail "Wrappers created on invalid buffer"
+    end
+    tap_pass
+end
+
+function test_cleanup_event
+    tap_start "Cleanup on fish_prompt event"
+    setup
+    set -g _ISLAND_PROFILES alpha
+    _island_wrap_cmd cat
+    if not functions -q cat
+        tap_fail "Wrapper function missing before cleanup"
+    end
+    emit fish_prompt
+    if set -q _ISLAND_WRAPPED_CMDS[1]
+        tap_fail "_ISLAND_WRAPPED_CMDS not cleared"
+    end
+    if functions -q cat
+        tap_fail "Wrapper function not removed"
+    end
+    emit fish_prompt
+    tap_pass
+end
+
+function test_island_refreshes_profiles
+    tap_start "island function refreshes profiles"
+    setup
+    set -gx ISLAND_STATUS_OUTPUT "first"
+    _island_chpwd
+    assert_eq "$_ISLAND_PROFILES" "first" "Initial profiles mismatch"
+
+    set -gx ISLAND_STATUS_OUTPUT "second"
+    island status >/dev/null 2>&1
+    assert_eq "$_ISLAND_PROFILES" "second" "Profiles not refreshed"
+    tap_pass
+end
+
+function test_paging_mode_skip
+    tap_start "Paging mode skips hook processing"
+    setup
+    set -g _ISLAND_PROFILES alpha
+    set -g __island_cmdline_buffer "/bin/echo hi"
+    set -g __island_cmdline_paging_mode 1  # Paging mode active (returns 0 = true)
+    _island_accept_line
+    # When in paging mode, the buffer should not be modified
+    assert_eq "$__island_cmdline_buffer" "/bin/echo hi" "Buffer modified during paging mode"
+    if set -q _ISLAND_WRAPPED_CMDS[1]
+        tap_fail "Commands wrapped during paging mode"
+    end
+    tap_pass
+end
+
+set TESTS \
+    test_profiles_tracking \
+    test_path_rewrite \
+    test_path_rewrite_quoted \
+    test_path_rewrite_escaped \
+    test_path_rewrite_space \
+    test_quoted_command_wrapping \
+    test_nosandbox \
+    test_and_variants \
+    test_pipe_wrapping \
+    test_redirections \
+    test_invalid_commandline \
+    test_cleanup_event \
+    test_island_refreshes_profiles \
+    test_paging_mode_skip
+
+if test (count $argv) -gt 0
+    if test "$argv[1]" = "--check-count"
+        set -l expected $argv[2]
+        if test (count $TESTS) -ne $expected
+            echo "Error: Expected $expected tests, but found "(count $TESTS)"."
+            exit 1
+        end
+        exit 0
+    end
+
+    set -l test_name $argv[1]
+    if not contains -- $test_name $TESTS
+        tap_fail "Unknown test $test_name"
+    end
+    $test_name
+    exit 0
+end
+
+tap_plan (count $TESTS)
+for t in $TESTS
+    eval $t
+end

--- a/tests/shell/test_hook.fish
+++ b/tests/shell/test_hook.fish
@@ -1,34 +1,11 @@
 #!/usr/bin/env fish
 # SPDX-License-Identifier: Apache-2.0 OR MIT
 
-set -g TEST_NUM 0
-set -g CURRENT_TEST_DESC ""
-
-function tap_start --argument-names desc
-    set -g TEST_NUM (math $TEST_NUM + 1)
-    set -g CURRENT_TEST_DESC $desc
-end
-
-function tap_debug --argument-names msg
-    echo "# DEBUG: $msg" >&2
-end
-
-function tap_fail --argument-names msg
-    echo "not ok $TEST_NUM - $CURRENT_TEST_DESC: $msg"
-    exit 1
-end
-
-function tap_pass
-    echo "ok $TEST_NUM - $CURRENT_TEST_DESC"
-end
-
-function tap_plan --argument-names count
-    echo "1..$count"
-end
-
 set -gx HOME (mktemp -d)
 set -l SCRIPT_DIR (dirname (status filename))
 set -l HOOK_SCRIPT "$SCRIPT_DIR/../../assets/shell/hook.fish"
+
+source "$SCRIPT_DIR/../tap.fish"
 
 set -x PATH "$SCRIPT_DIR/test_stub:$PATH"
 
@@ -48,7 +25,9 @@ function commandline
                 return 1
             end
         case "--current-buffer"
-            printf "%s" "$__island_cmdline_buffer"
+            for line in $__island_cmdline_buffer
+                echo $line
+            end
             return 0
         case "--replace"
             set -l idx 2
@@ -114,7 +93,7 @@ function test_profiles_tracking
     set -gx ISLAND_STATUS_EXIT 1
     _island_chpwd
     if set -q _ISLAND_PROFILES[1]
-        tap_fail "_ISLAND_PROFILES not cleared on failure"
+        tap_fail "_ISLAND_PROFILES not cleared on island status error"
     end
     tap_pass
 end
@@ -122,7 +101,7 @@ end
 function test_path_rewrite
     tap_start "Path command rewrites buffer"
     setup
-    set -g _ISLAND_PROFILES alpha
+    set -g _ISLAND_PROFILES profile1
     set -g __island_cmdline_buffer "/bin/echo hi"
     _island_accept_line
     assert_eq "$__island_cmdline_buffer" "island run -- /bin/echo hi" "Buffer not rewritten"
@@ -132,7 +111,7 @@ end
 function test_path_rewrite_quoted
     tap_start "Path rewrite preserves quoting"
     setup
-    set -g _ISLAND_PROFILES alpha
+    set -g _ISLAND_PROFILES profile1
     set -g __island_cmdline_buffer "./'my binary' arg"
     _island_accept_line
     assert_eq "$__island_cmdline_buffer" "island run -- ./'my binary' arg" "Quoted path not rewritten"
@@ -142,7 +121,7 @@ end
 function test_path_rewrite_escaped
     tap_start "Path rewrite handles escaped spaces"
     setup
-    set -g _ISLAND_PROFILES alpha
+    set -g _ISLAND_PROFILES profile1
     set -g __island_cmdline_buffer "./my\\ binary"
     _island_accept_line
     assert_eq "$__island_cmdline_buffer" "island run -- ./my\\ binary" "Escaped path not rewritten"
@@ -152,7 +131,7 @@ end
 function test_path_rewrite_space
     tap_start "Path rewrite handles space-quoted path"
     setup
-    set -g _ISLAND_PROFILES alpha
+    set -g _ISLAND_PROFILES profile1
     set -g __island_cmdline_buffer "./my binary"
     _island_accept_line
     assert_eq "$__island_cmdline_buffer" "island run -- ./my binary" "Space path not rewritten"
@@ -162,7 +141,7 @@ end
 function test_quoted_command_wrapping
     tap_start "Quoted args keep command wrapping"
     setup
-    set -g _ISLAND_PROFILES alpha
+    set -g _ISLAND_PROFILES profile1
     functions -e ls 2>/dev/null
     set -g __island_cmdline_buffer "ls \"file with >> weird name\""
     _island_accept_line
@@ -174,7 +153,7 @@ end
 function test_nosandbox
     tap_start "nosandbox bypasses wrapping"
     setup
-    set -g _ISLAND_PROFILES alpha
+    set -g _ISLAND_PROFILES profile1
     set -g __island_cmdline_buffer "nosandbox /bin/echo hi"
     _island_accept_line
     assert_eq "$__island_cmdline_buffer" "nosandbox /bin/echo hi" "Buffer should remain unchanged"
@@ -182,10 +161,59 @@ function test_nosandbox
     tap_pass
 end
 
+function test_operators
+    tap_start "Shell operators && and ||"
+    setup
+    set -g _ISLAND_PROFILES profile1
+
+    # Test && operator with spaces
+    set -g __island_cmdline_buffer "head a && tail b"
+    _island_accept_line
+    assert_contains head "first command not wrapped with &&" $_ISLAND_WRAPPED_CMDS
+    assert_contains tail "command not wrapped after &&" $_ISLAND_WRAPPED_CMDS
+
+    # Test || operator with spaces
+    set -g __island_cmdline_buffer "head a || tail b"
+    _island_accept_line
+    assert_contains head "first command not wrapped with ||" $_ISLAND_WRAPPED_CMDS
+    assert_contains tail "command not wrapped after ||" $_ISLAND_WRAPPED_CMDS
+
+    # Test || operator without spaces
+    set -g __island_cmdline_buffer "head||tail"
+    _island_accept_line
+    assert_contains head "head not wrapped with ||" $_ISLAND_WRAPPED_CMDS
+    assert_contains tail "tail not wrapped after || without spaces" $_ISLAND_WRAPPED_CMDS
+
+    # Test && operator without spaces
+    set -g __island_cmdline_buffer "head&&tail"
+    _island_accept_line
+    assert_contains head "head not wrapped with &&" $_ISLAND_WRAPPED_CMDS
+    assert_contains tail "tail not wrapped after && without spaces" $_ISLAND_WRAPPED_CMDS
+
+    # Test || in double quotes (should not be treated as separator)
+    set -g __island_cmdline_buffer "head \"||\" tail"
+    _island_accept_line
+    assert_contains head "head not wrapped when || is quoted" $_ISLAND_WRAPPED_CMDS
+    assert_not_contains tail "tail should not be wrapped when || is in quotes" $_ISLAND_WRAPPED_CMDS
+
+    # Test && in single quotes (should not be treated as separator)
+    set -g __island_cmdline_buffer "'head&&tail'"
+    _island_accept_line
+    assert_not_contains head "head should not be wrapped when inside single quotes" $_ISLAND_WRAPPED_CMDS
+    assert_not_contains tail "tail should not be wrapped when inside single quotes" $_ISLAND_WRAPPED_CMDS
+
+    set -g __island_cmdline_buffer '"head&&tail"'
+    _island_accept_line
+    assert_not_contains head "head should not be wrapped when inside double quotes" $_ISLAND_WRAPPED_CMDS
+    assert_not_contains tail "tail should not be wrapped when inside double quotes" $_ISLAND_WRAPPED_CMDS
+
+    tap_pass
+end
+
 function test_and_variants
     tap_start "Logical and separators"
     setup
-    set -g _ISLAND_PROFILES alpha
+    set -g _ISLAND_PROFILES profile1
 
     set -g __island_cmdline_buffer "head a; and tail b"
     _island_accept_line
@@ -204,7 +232,7 @@ end
 function test_pipe_wrapping
     tap_start "Wrapping with pipe variants"
     setup
-    set -g _ISLAND_PROFILES alpha
+    set -g _ISLAND_PROFILES profile1
     set -g __island_cmdline_buffer "echo hi &| cat 2>| head"
     _island_accept_line
     tap_debug "Wrapped: $_ISLAND_WRAPPED_CMDS"
@@ -216,7 +244,7 @@ end
 function test_redirections
     tap_start "Redirections split tokens without new command"
     setup
-    set -g _ISLAND_PROFILES alpha
+    set -g _ISLAND_PROFILES profile1
     functions -e ls 2>/dev/null
 
     set -g __island_cmdline_buffer "ls>a"
@@ -245,7 +273,7 @@ end
 function test_invalid_commandline
     tap_start "Invalid commandline skips wrapping"
     setup
-    set -g _ISLAND_PROFILES alpha
+    set -g _ISLAND_PROFILES profile1
     set -g __island_cmdline_buffer "echo 'unterminated"
     set -g __island_cmdline_valid_status 2
     _island_accept_line
@@ -259,7 +287,7 @@ end
 function test_cleanup_event
     tap_start "Cleanup on fish_prompt event"
     setup
-    set -g _ISLAND_PROFILES alpha
+    set -g _ISLAND_PROFILES profile1
     _island_wrap_cmd cat
     if not functions -q cat
         tap_fail "Wrapper function missing before cleanup"
@@ -278,20 +306,20 @@ end
 function test_island_refreshes_profiles
     tap_start "island function refreshes profiles"
     setup
-    set -gx ISLAND_STATUS_OUTPUT "first"
+    set -gx ISLAND_STATUS_OUTPUT "profile1"
     _island_chpwd
-    assert_eq "$_ISLAND_PROFILES" "first" "Initial profiles mismatch"
+    assert_eq "$_ISLAND_PROFILES" "profile1" "Initial profiles mismatch"
 
-    set -gx ISLAND_STATUS_OUTPUT "second"
+    set -gx ISLAND_STATUS_OUTPUT "profile2"
     island status >/dev/null 2>&1
-    assert_eq "$_ISLAND_PROFILES" "second" "Profiles not refreshed"
+    assert_eq "$_ISLAND_PROFILES" "profile2" "Profiles not refreshed"
     tap_pass
 end
 
 function test_paging_mode_skip
     tap_start "Paging mode skips hook processing"
     setup
-    set -g _ISLAND_PROFILES alpha
+    set -g _ISLAND_PROFILES profile1
     set -g __island_cmdline_buffer "/bin/echo hi"
     set -g __island_cmdline_paging_mode 1  # Paging mode active (returns 0 = true)
     _island_accept_line
@@ -311,6 +339,7 @@ set TESTS \
     test_path_rewrite_space \
     test_quoted_command_wrapping \
     test_nosandbox \
+    test_operators \
     test_and_variants \
     test_pipe_wrapping \
     test_redirections \
@@ -319,25 +348,4 @@ set TESTS \
     test_island_refreshes_profiles \
     test_paging_mode_skip
 
-if test (count $argv) -gt 0
-    if test "$argv[1]" = "--check-count"
-        set -l expected $argv[2]
-        if test (count $TESTS) -ne $expected
-            echo "Error: Expected $expected tests, but found "(count $TESTS)"."
-            exit 1
-        end
-        exit 0
-    end
-
-    set -l test_name $argv[1]
-    if not contains -- $test_name $TESTS
-        tap_fail "Unknown test $test_name"
-    end
-    $test_name
-    exit 0
-end
-
-tap_plan (count $TESTS)
-for t in $TESTS
-    eval $t
-end
+tap_run $argv

--- a/tests/shell/test_stub/island
+++ b/tests/shell/test_stub/island
@@ -1,0 +1,17 @@
+#!/usr/bin/env sh
+# SPDX-License-Identifier: Apache-2.0 OR MIT
+
+# A mocked island command for shell hook testing
+case "$1" in
+    status)
+        echo "$ISLAND_STATUS_OUTPUT"
+        exit "${ISLAND_STATUS_EXIT:-0}"
+        ;;
+    run)
+        if [ -n "$ISLAND_RUN_LOG" ]; then
+            echo "$2" >>"$ISLAND_RUN_LOG"
+        fi
+        exit 0
+        ;;
+esac
+exit 0

--- a/tests/tap.fish
+++ b/tests/tap.fish
@@ -1,0 +1,52 @@
+#!/usr/bin/env fish
+# SPDX-License-Identifier: Apache-2.0 OR MIT
+
+set -g TEST_NUM 0
+set -g CURRENT_TEST_DESC ""
+
+function tap_start --argument-names desc
+    set -g TEST_NUM (math $TEST_NUM + 1)
+    set -g CURRENT_TEST_DESC $desc
+end
+
+function tap_debug --argument-names msg
+    echo "# DEBUG: $msg" >&2
+end
+
+function tap_fail --argument-names msg
+    echo "not ok $TEST_NUM - $CURRENT_TEST_DESC: $msg"
+    exit 1
+end
+
+function tap_pass
+    echo "ok $TEST_NUM - $CURRENT_TEST_DESC"
+end
+
+function tap_plan --argument-names count
+    echo "1..$count"
+end
+
+function tap_run
+    if test (count $argv) -gt 0
+        if test "$argv[1]" = "--check-count"
+            set -l expected $argv[2]
+            if test (count $TESTS) -ne $expected
+                echo "Error: Expected $expected tests, but found "(count $TESTS)"."
+                exit 1
+            end
+            exit 0
+        end
+
+        set -l test_name $argv[1]
+        if not contains -- $test_name $TESTS
+            tap_fail "Unknown test $test_name"
+        end
+        $test_name
+        exit 0
+    end
+
+    tap_plan (count $TESTS)
+    for t in $TESTS
+        eval $t
+    end
+end


### PR DESCRIPTION
With this I think the experience is fairly similar to the zsh case, with similar limitations, e.g. no command substitution, but also no automatic alias expansion yet due to alias actually being functions, rather than something we can just query.

There is also a caveat regarding pipelines (see third commit), and I'm not sure how best to handle it.

Demo:

```fish
(0.001s) linux-devbox-2 (mao) ~ at 23:58:24
> exa / # outside sandbox
bin   boot.2  etc   lib    mnt  proc  run   snapshots  sys  usr
boot  dev     home  lib64  opt  root  sbin  srv        tmp  var
(0.003s) linux-devbox-2 (mao) ~ at 23:58:26
> cd island/
(0.002s) linux-devbox-2 (mao; fish-hook) ~/island I[island] at 23:58:27
> exa / # inside sandbox
Permission denied: / - code: 13

Skipped 1 directories due to permission denied: 
  /
(0.003s) linux-devbox-2 (mao; fish-hook) ~/island I[island] at 23:58:31
> ls / # ls is a built-in function wrapping ls in fish, so not sandboxed
bin@  boot/  boot.2/  dev/  etc/  home/  lib@  lib64@  mnt/  opt/  proc/  root/  run/  sbin@  snapshots/  srv/  sys/  tmp/  usr/  var/
(0.001s) linux-devbox-2 (mao; fish-hook) ~/island I[island] at 23:59:34
> grep -R 'BEGIN OPENSSH PRIVATE KEY' ~/.ssh # similarly, grep is a built in alias, so not sandboxed
/home/mao/.ssh/id_ed25519:-----BEGIN OPENSSH PRIVATE KEY-----
```

Automatic insertion of `island run` for absolute path:

```
# I typed "/bin/grep -R ...", then enter
> island run -- /bin/grep -R 'BEGIN OPENSSH PRIVATE KEY' ~/.ssh
/bin/grep: /home/mao/.ssh: Permission denied
```

`abbr` expansion (I typed `gp`, then pressed enter twice (required to press enter twice due to limitation))

```
> git push -v
Pushing to https://github.com/micromaomao/island.git
fatal: cannot exec '/home/mao/.vscode-server/cli/servers/Stable-618725e67565b290ba4da6fe2d29f8fa1d4e3622/server/extensions/git/dist/askpass.sh': Permission denied
fatal: could not read Username for 'https://github.com': Permission denied
```

Closes: #6 