### PR TITLE
If an alias uses `command`, modify it to not do that

### DIFF
--- a/assets/shell/hook.zsh
+++ b/assets/shell/hook.zsh
@@ -115,6 +115,10 @@ function _island_wrap_cmd() {
                 shift words
             elif [[ "$word" == (nocorrect|noglob|exec|eval) ]]; then
                 shift words
+            elif [[ "$word" == command ]]; then
+                shift words
+                word="${words[1]}"
+                aliases[${(Q)cmd}]="${aliases[${(Q)cmd}]/command /}"
             else
                 break
             fi


### PR DESCRIPTION
First of all thank you for making this tool, this is great!

I did hit a snag while testing it, in that it didn't actually sandbox `ls` in my environment. I thought it might have been something with the precmds and accept-lines I already had, but instead it turned out to be an issue with the `ls` alias I get from using the GRML ZSH config. It [defines](https://github.com/grml/grml-etc-core/blob/master/etc/zsh/zshrc#L2443) the alias as:

```
alias ls="command ls ${ls_options:+${ls_options[*]}}"
```

I haven't found any adverse effects from the the change in this PR that strips the `command` from any alias.