### PR TITLE
Add '/nix/store' to allowed paths

### DIFF
--- a/assets/landlock/island-default-base.toml
+++ b/assets/landlock/island-default-base.toml
@@ -21,6 +21,7 @@ parent = [
     "/lib",
     "/sbin",
     "/usr",
+    "/nix/store",
 ]
 
 # Safe writable devices.


### PR DESCRIPTION
make default assets work with nix

in future good idea would be to make a nix derivation that create only needed path inside /nix/store